### PR TITLE
fixed desktop media query

### DIFF
--- a/app/assets/stylesheets/components/_media-queries.scss
+++ b/app/assets/stylesheets/components/_media-queries.scss
@@ -27,9 +27,14 @@ body {
     height: 100%;
   }
   .hidden-text {
-      margin-top: -20vh;
-      color: white;
-      visibility: visible;
+    // margin-top: -20vh;
+    color: white;
+    visibility: visible;
+  }
+  #sorry-text {
+    position: static;
+    margin-top: 66px;
+    font-size: 40px;
   }
 }
 

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -30,7 +30,7 @@
       <%= yield %>
     <!-- </div> -->
     <div class="hider">
-      <h1 class="hidden-text">Sorry, Reko is mobile only.</h1>
+      <h1 id="sorry-text" class="hidden-text">Sorry, Reko is mobile only.</h1>
     </div>
     <%= javascript_include_tag 'application' %>
     <%= javascript_pack_tag 'application' %>
@@ -38,3 +38,4 @@
   </body>
 
 </html>
+


### PR DESCRIPTION
- text is now above the gif
- i assigned an ID so it overrides the positioning options for the h1 elements